### PR TITLE
Fixed crash in mountedVolumeInfoAt when diskDescription is nil

### DIFF
--- a/VolumeManager/VolumeManager.m
+++ b/VolumeManager/VolumeManager.m
@@ -357,9 +357,11 @@ void diskEjected(DADiskRef disk, DADissenterRef dissenter, void *context)
         CFDictionaryRef diskDescription = DADiskCopyDescription(disk);
         CFRelease(disk);
 
-        NSDictionary *properties =
-            [self propertiesForDAProperties:(__bridge NSDictionary*)diskDescription];
-        CFRelease(diskDescription);
+        NSDictionary *properties;
+        if (diskDescription) {
+            properties = [self propertiesForDAProperties:(__bridge NSDictionary*)diskDescription];
+            CFRelease(diskDescription);
+        }
 
         return properties;
     }


### PR DESCRIPTION
It is possible that diskDescription will be nil causing a crash when we try to use it.  This change checks diskDescription first.
